### PR TITLE
feat: Add persistence for chat messages

### DIFF
--- a/backend/models/Message.js
+++ b/backend/models/Message.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const MessageSchema = new mongoose.Schema({
+    text: {
+        type: String,
+        required: true,
+    },
+    sender: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
+        required: true,
+    },
+    room: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Room',
+        required: true,
+    },
+}, { timestamps: true });
+
+module.exports = mongoose.model('Message', MessageSchema);


### PR DESCRIPTION
This commit introduces message persistence, allowing chat history to be saved and loaded for each room.

Key changes:

- **New Message Model (`backend/models/Message.js`):**
  - Created a new Mongoose schema to store messages, including the message text, a reference to the sender, and a reference to the room.

- **Backend (`socketHandler.js`):**
  - The `chatMessage` event handler now saves every new message to the MongoDB database.
  - The `joinRoom` event handler now fetches the last 50 messages for the room and sends them to the joining client via a new `message_history` event.

- **Frontend (`main.js`):**
  - Added a listener for the `message_history` event. When a user joins a room, this listener receives the past messages and renders them, providing conversation context.
  - The `appendMessage` and `handleSendMessage` functions were updated to handle optimistic UI updates and prevent duplicate rendering.